### PR TITLE
Fix day reoccur begin

### DIFF
--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -122,6 +122,48 @@ describe(`check state creation`, () => {
   });
 });
 
+describe(`check integrated transaction reoccurence`, () => {
+  it(`returns the correct number of daily reoccurences`, () => {
+    let singleTransaction = resolvedTestData.transactions
+      .set([
+        {
+          id: `every-other-week`,
+          raccount: `account`,
+          category: `bi-weekly paycheck`,
+          type: `income`,
+          start: `2018-02-04`,
+          rtype: `day`,
+          value: 1200,
+          cycle: 14
+        }
+      ])
+      .accounts.set([
+        {
+          name: 'account',
+          starting: 0,
+          interest: 0.01,
+          vehicle: 'operating'
+        }
+      ])
+      .reCalc();
+
+    // This should occur every two weeks (cycle = 14)
+    // beginning on Feb 4th, 2018, but the graphrange doesn't
+    // start until March 1st, 2018. This means the first time it
+    // shows up should be on March 4th. This will mean we have
+    // 13 total occurences of the transaction in our range.
+    // (The 14th lands on Sept 2nd.) If we erroneously show the
+    // first occurence at the beginning of the graphrange, which
+    // is 3 days earlier, we would see 14 occurences instead.
+
+    // the max with a single transaction should === value of that transaction
+    expect(singleTransaction.charts.state.BarChartMax).toEqual(1200);
+    // the max should be our 13 occurences * value + starting ($0 here)
+    // that is: 13 * 1200 = 15600
+    expect(singleTransaction.charts.state.LineChartMax).toEqual(15600);
+  });
+});
+
 describe(`check resolveData handles paybacks`, () => {
   it(`has the correct BarChartExpense structure`, () => {
     expect(resolvedTestData.charts.state.BarChartExpense).toEqual(

--- a/src/state/resolveFinancials/resolveTransactions/transactionDailyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionDailyReoccur.test.js
@@ -5,6 +5,7 @@ import getDate from 'date-fns/fp/getDate';
 import getMonth from 'date-fns/fp/getMonth';
 
 import { transactionDailyReoccur } from './index.js';
+import { convertRangeToInterval } from './index.js';
 
 describe(`check transactionDailyReoccur`, () => {
   const transaction = {
@@ -19,16 +20,17 @@ describe(`check transactionDailyReoccur`, () => {
     value: Big(150)
   };
   let graphRange = {
-    start: startOfDay('2018-01-01'),
-    end: startOfDay('2018-02-01')
+    start: startOfDay('2018-03-01'),
+    end: startOfDay('2018-06-01')
   };
-  let seedDate = graphRange.start;
-  let occurrences = Big(1);
+  let interval = convertRangeToInterval(transaction, graphRange);
+  let seedDate = interval.start;
+
   it(`has all the correct properties`, () => {
     let resolvedTestData = transactionDailyReoccur({
       transaction,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
     expect(resolvedTestData).toHaveProperty('date');
     expect(resolvedTestData).toHaveProperty('y');
@@ -38,57 +40,106 @@ describe(`check transactionDailyReoccur`, () => {
     let resolvedTestData = transactionDailyReoccur({
       transaction,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
-    expect(getMonth(resolvedTestData.date)).toBe(0);
-    expect(getDate(resolvedTestData.date)).toBe(2);
+    // where January = 0, 20XX-03-22 will be Month = 2
+    expect(getMonth(resolvedTestData.date)).toBe(2);
+    expect(getDate(resolvedTestData.date)).toBe(22);
   });
 
   it(`returns a cycle of 1`, () => {
     let testData = { ...transaction, cycle: Big(1) };
+    // difference should be 1 + 21 days between the start of the graph range
+    // and when the first transaction is produced
+
     let resolvedTestData = transactionDailyReoccur({
       transaction: testData,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
     expect(
       differenceInCalendarDays(graphRange.start)(resolvedTestData.date)
+    ).toBe(21);
+
+    let secondIteration = transactionDailyReoccur({
+      transaction: testData,
+      seedDate: resolvedTestData.date,
+      occurrences: Big(1)
+    });
+    expect(
+      differenceInCalendarDays(transaction.start)(secondIteration.date)
     ).toBe(1);
   });
 
   it(`returns a cycle of 3`, () => {
     let testData = { ...transaction, cycle: Big(3) };
+    // difference should be 3 + 21 days between the start of the graph range
+    // and when the first transaction is produced
+
     let resolvedTestData = transactionDailyReoccur({
       transaction: testData,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
     expect(
       differenceInCalendarDays(graphRange.start)(resolvedTestData.date)
+    ).toBe(21);
+
+    let secondIteration = transactionDailyReoccur({
+      transaction: testData,
+      seedDate: resolvedTestData.date,
+      occurrences: Big(1)
+    });
+    expect(
+      differenceInCalendarDays(transaction.start)(secondIteration.date)
     ).toBe(3);
   });
 
   it(`returns a cycle of 5`, () => {
     let testData = { ...transaction, cycle: Big(5) };
+    // difference should be 5 + 21 days between the start of the graph range
+    // and when the first transaction is produced
+
     let resolvedTestData = transactionDailyReoccur({
       transaction: testData,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
     expect(
       differenceInCalendarDays(graphRange.start)(resolvedTestData.date)
+    ).toBe(21);
+
+    let secondIteration = transactionDailyReoccur({
+      transaction: testData,
+      seedDate: resolvedTestData.date,
+      occurrences: Big(1)
+    });
+    expect(
+      differenceInCalendarDays(transaction.start)(secondIteration.date)
     ).toBe(5);
   });
 
   it(`returns a cycle of 14`, () => {
     let testData = { ...transaction, cycle: Big(14) };
+    // difference should be 14 + 21 days between the start of the graph range
+    // and when the first transaction is produced
+
     let resolvedTestData = transactionDailyReoccur({
       transaction: testData,
       seedDate,
-      occurrences
+      occurrences: Big(0)
     });
     expect(
       differenceInCalendarDays(graphRange.start)(resolvedTestData.date)
+    ).toBe(21);
+
+    let secondIteration = transactionDailyReoccur({
+      transaction: testData,
+      seedDate: resolvedTestData.date,
+      occurrences: Big(1)
+    });
+    expect(
+      differenceInCalendarDays(transaction.start)(secondIteration.date)
     ).toBe(14);
   });
 });


### PR DESCRIPTION
Previously the daily reoccur would start on the first day of our graphing range. The correct expectation is that it would cycle based on when it started. This change brings reality in line with the expectation.