### PR TITLE
expenses on debt

### DIFF
--- a/cypress/integration/accounts/account_modification.js
+++ b/cypress/integration/accounts/account_modification.js
@@ -56,7 +56,7 @@ describe('Account Modifications Tests', () => {
       .parent()
       .parent()
       .find('select')
-      .select('Debt');
+      .select('Loan');
 
     cy.get('form').submit();
     cy.get('#accounts')

--- a/cypress/integration/accounts/form_submission.js
+++ b/cypress/integration/accounts/form_submission.js
@@ -35,7 +35,7 @@ describe('Account Form Tests', () => {
       .parent()
       .parent()
       .find('select')
-      .select('Debt');
+      .select('Loan');
 
     cy.get('form').submit();
     cy.get('#accounts')

--- a/cypress/integration/debtpaybacks/debypayback_delete.js
+++ b/cypress/integration/debtpaybacks/debypayback_delete.js
@@ -15,7 +15,7 @@ describe('Debt Payback Form Tests', () => {
       .parent()
       .parent()
       .find('select')
-      .select('Debt');
+      .select('Loan');
     cy.get('form')
       .contains('starting')
       .parent()

--- a/cypress/integration/debtpaybacks/debypayback_modification.js
+++ b/cypress/integration/debtpaybacks/debypayback_modification.js
@@ -15,7 +15,7 @@ describe('Debt Payback Form Tests', () => {
       .parent()
       .parent()
       .find('select')
-      .select('Debt');
+      .select('Loan');
     cy.get('form')
       .contains('starting')
       .parent()

--- a/cypress/integration/debtpaybacks/form_submission.js
+++ b/cypress/integration/debtpaybacks/form_submission.js
@@ -15,7 +15,7 @@ describe('Debt Payback Form Tests', () => {
       .parent()
       .parent()
       .find('select')
-      .select('Debt');
+      .select('Loan');
     cy.get('form')
       .contains('starting')
       .parent()

--- a/src/pages/flow/accountInput.js
+++ b/src/pages/flow/accountInput.js
@@ -94,7 +94,8 @@ class AccountInput extends React.Component {
                           <div className="select">
                             <Field component="select" name="vehicle">
                               <option value="operating">Operating</option>
-                              <option value="debt">Debt</option>
+                              <option value="loan">Loan</option>
+                              <option value="credit line">Credit Line</option>
                               <option value="investment">Investment</option>
                             </Field>
                           </div>

--- a/src/pages/flow/accountTransactionInput.js
+++ b/src/pages/flow/accountTransactionInput.js
@@ -67,7 +67,12 @@ class AccountTransactionInput extends React.Component {
                                   Select an Option
                                 </option>
                                 {model.state.accounts
-                                  .filter(account => account.vehicle === 'debt')
+                                  .filter(
+                                    account =>
+                                      account.vehicle === 'debt' ||
+                                      account.vehicle === 'loan' ||
+                                      account.vehicle === 'credit line'
+                                  )
                                   .map(account => (
                                     <option
                                       key={account.name}

--- a/src/pages/flow/accounts.js
+++ b/src/pages/flow/accounts.js
@@ -63,7 +63,10 @@ class AccountFlow extends React.Component {
                   </div>
                   <div>
                     {model.state.accountsComputed.filter(
-                      account => account.vehicle === 'debt'
+                      account =>
+                        account.vehicle === 'debt' ||
+                        account.vehicle === 'loan' ||
+                        account.vehicle === 'credit line'
                     ).length === 0 ? null : (
                       <AccountTransactionInput tabClick={this.tabClick} />
                     )}

--- a/src/pages/flow/accounts.js
+++ b/src/pages/flow/accounts.js
@@ -139,11 +139,21 @@ const AccountTable = ({ data, actions }) =>
   );
 
 const DebtTable = ({ data, actions }) =>
-  data.filter(account => account.vehicle === 'debt').length === 0 || !data ? (
+  data.filter(
+    account =>
+      account.vehicle === 'debt' ||
+      account.vehicle === 'loan' ||
+      account.vehicle === 'credit line'
+  ).length === 0 || !data ? (
     <div>There are no debts to show.</div>
   ) : (
     data
-      .filter(account => account.vehicle === 'debt')
+      .filter(
+        account =>
+          account.vehicle === 'debt' ||
+          account.vehicle === 'loan' ||
+          account.vehicle === 'credit line'
+      )
       .map(account => (
         <div className="media box" key={account.name}>
           <div className="media-content">

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -200,12 +200,19 @@ const resolveBarChart = (dataRaw, { graphRange }) => {
 // and takes the value of each that applies
 // and reduces it down into one value
 const zipTogethor = account => arr =>
-  arr.reduce((accumlator, d) => {
-    if (d.raccount === account.name) {
-      let flatten = d.stack.map(e => e[1] - e[0]);
+  arr.reduce((accumlator, transaction) => {
+    if (transaction.raccount === account.name) {
+      let flatten = transaction.stack
+        .map(e => e[1] - e[0])
+        .map(
+          d =>
+            (account.vehicle === 'credit line' && transaction.type === 'expense'
+              ? -1
+              : 1) * d
+        );
       return accumlator.length === 0
         ? flatten
-        : accumlator.map((d, i, thisArray) => d + flatten[i]);
+        : accumlator.map((d, i) => d + flatten[i]);
     } else {
       return accumlator;
     }
@@ -218,7 +225,7 @@ const twoSteppedBalance = (starting, accountStack, barChartStack) => {
     if (value === undefined) {
       return 0;
     } else {
-      return Math.abs(value);
+      return value;
     }
   };
 

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -205,7 +205,7 @@ const zipTogethor = account => arr =>
     }
   }, []);
 
-const twoSteppedBalance = (starting, accountStack, barChartStack) => {
+const twoSteppedBalance = (starting, accountStack, barChartStack, slope) => {
   // we use this function as the iterator can hit
   // undefined values if income or expense array is empty
   const extractValue = value => {
@@ -224,7 +224,9 @@ const twoSteppedBalance = (starting, accountStack, barChartStack) => {
   let values = [];
   let prevVal = extractValue(starting);
   for (let iterator = 0; iterator < arrayLength; iterator++) {
-    let firstStep = prevVal - extractValue(accountStack.expense[iterator]);
+    let firstStep =
+      prevVal +
+      (slope === 'pos' ? 1 : -1) * extractValue(accountStack.expense[iterator]);
     let secondStep = firstStep + extractValue(accountStack.income[iterator]);
 
     values.push({
@@ -251,14 +253,15 @@ const resolveAccountChart = ({ accounts, income, expense }) => {
         let accountZipper = zipTogethor(account);
         accountStack.income = accountZipper(income);
         accountStack.expense = accountZipper(expense);
-
+        if (account.name === 'cc') console.log(account);
         let barChartStack = [].concat(income, expense)[0].stack;
         let finalZippedLine = {
           account: account,
           values: twoSteppedBalance(
             account.starting,
             accountStack,
-            barChartStack
+            barChartStack,
+            account.vehicle === `debt` ? 'pos' : 'neg'
           ),
           interest: account.interest,
           vehicle: account.vehicle

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -211,7 +211,7 @@ const zipTogethor = account => arr =>
     }
   }, []);
 
-const twoSteppedBalance = (starting, accountStack, barChartStack, slope) => {
+const twoSteppedBalance = (starting, accountStack, barChartStack) => {
   // we use this function as the iterator can hit
   // undefined values if income or expense array is empty
   const extractValue = value => {
@@ -230,9 +230,7 @@ const twoSteppedBalance = (starting, accountStack, barChartStack, slope) => {
   let values = [];
   let prevVal = extractValue(starting);
   for (let iterator = 0; iterator < arrayLength; iterator++) {
-    let firstStep =
-      prevVal +
-      (slope === 'pos' ? 1 : -1) * extractValue(accountStack.expense[iterator]);
+    let firstStep = prevVal - extractValue(accountStack.expense[iterator]);
     let secondStep = firstStep + extractValue(accountStack.income[iterator]);
 
     values.push({
@@ -266,8 +264,7 @@ const resolveAccountChart = ({ accounts, income, expense }) => {
           values: twoSteppedBalance(
             account.starting,
             accountStack,
-            barChartStack,
-            account.vehicle === `credit line` ? 'pos' : 'neg'
+            barChartStack
           ),
           interest: account.interest,
           vehicle: account.vehicle

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -199,6 +199,10 @@ const resolveBarChart = (dataRaw, { graphRange }) => {
 // and then loops through each transaction
 // and takes the value of each that applies
 // and reduces it down into one value
+// modifying this on the fly for credit lines
+// seems real fragile, TODO make the line chart
+// not dependent on the bar chart as decoupling
+// should likely make it less fragile
 const zipTogethor = account => arr =>
   arr.reduce((accumlator, transaction) => {
     if (transaction.raccount === account.name) {

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -198,7 +198,7 @@ describe(`check resolveData handles paybacks`, () => {
       resolvedTestData.charts.state.AccountChart[0].values[count].value
     ).toEqual(-23260);
 
-    // this tests the expense, which reduces the balance of the debt account
+    // this tests the expense, which increases the balance of the debt account
     // $30000 starting - 26260 = 3740
     expect(
       resolvedTestData.charts.state.AccountChart[1].values[count].value

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -206,6 +206,77 @@ describe(`check resolveData handles paybacks`, () => {
   });
 });
 
+describe(`check resolveData handles credit lines`, () => {
+  let singleTestData = {
+    transactions: [
+      {
+        id: `expense-on-credit-ilne`,
+        raccount: `account2`,
+        description: `description`,
+        category: `test exp`,
+        type: `expense`,
+        start: `2018-03-22`,
+        rtype: `day`,
+        cycle: 14,
+        value: 1000
+      }
+    ],
+    accounts: [
+      {
+        name: 'account1',
+        starting: 15000,
+        interest: 0.01,
+        vehicle: 'operating'
+      },
+      {
+        name: 'account2',
+        starting: 30000,
+        interest: 18.0,
+        vehicle: 'credit line',
+        payback: {
+          description: `payback`,
+          category: 'account2 payback',
+          transactions: [
+            {
+              id: `payback1-test`,
+              raccount: 'account1',
+              start: `2018-03-22`,
+              rtype: `day`,
+              cycle: 1,
+              value: 40
+            },
+            {
+              id: `payback2-test`,
+              raccount: 'account1',
+              start: `2018-03-22`,
+              rtype: `day`,
+              cycle: 3,
+              value: 180
+            }
+          ]
+        }
+      }
+    ],
+    charts: { GraphRange: graphRange }
+  };
+  let resolvedTestData = create(AppModel, singleTestData).reCalc();
+
+  it(`ends with the correct balance`, () => {
+    // that is 163 days between start and end (plus 1 for the end day)
+    // payback is ~$100 a day, where the expense is $1000 every 14
+    // on the balance of $30000, we should be paying down ~$400 every 14 days
+    // daily payback: 40 * 164 = 6560
+    // every 3 day payback: 163 / 3 = 54.3 => 55 * 180 = 9900
+    // 14 day expense: 163 / 14 = 11.6 => 12 * 1000 = 12000
+    // 30000 + 12000 - 6560 - 9900 = 25540
+    const count =
+      resolvedTestData.charts.state.AccountChart[1].values.length - 1;
+    expect(
+      resolvedTestData.charts.state.AccountChart[1].values[count].value
+    ).toEqual(25540);
+  });
+});
+
 describe('checks modifications', () => {
   let allDates = eachDayOfInterval(graphRange);
   let stackStructure = allDates.map(day => {

--- a/src/state/resolveFinancials/index.testdata.js
+++ b/src/state/resolveFinancials/index.testdata.js
@@ -116,7 +116,7 @@ let testData = {
       name: 'account3',
       starting: 30000,
       interest: 6.0,
-      vehicle: 'debt',
+      vehicle: 'loan',
       payback: {
         description: `payback`,
         category: 'account3 payback',

--- a/src/state/resolveFinancials/seedData.js
+++ b/src/state/resolveFinancials/seedData.js
@@ -153,7 +153,7 @@ let seedTwo = {
       name: 'account3',
       starting: 30000,
       interest: 6.0,
-      vehicle: 'debt',
+      vehicle: 'loan',
       payback: {
         id: `sasdqljg`,
         description: `payback`,


### PR DESCRIPTION
Expenses, when attached to a credit line, actually _increase_ the balance whereas normally we only consider transfers against a debt type. This splits the debt into `loan` and `credit line`. The `loan` type only expects transfers and acts similar to before. The credit line expects both transfers and expenses where expenses actually increase the balance (where every other type it reduces the balance).