### PR TITLE
credit cards and occurrences

### DIFF
--- a/cypress/integration/debtpaybacks/debypayback_delete.js
+++ b/cypress/integration/debtpaybacks/debypayback_delete.js
@@ -63,7 +63,7 @@ describe('Debt Payback Form Tests', () => {
       .find('input')
       .type('2019-05-28');
     cy.get('form')
-      .contains('occurences')
+      .contains('occurrences')
       .parent()
       .parent()
       .find('input')

--- a/cypress/integration/debtpaybacks/debypayback_modification.js
+++ b/cypress/integration/debtpaybacks/debypayback_modification.js
@@ -63,7 +63,7 @@ describe('Debt Payback Form Tests', () => {
       .find('input')
       .type('2019-05-28');
     cy.get('form')
-      .contains('occurences')
+      .contains('occurrences')
       .parent()
       .parent()
       .find('input')

--- a/cypress/integration/debtpaybacks/form_submission.js
+++ b/cypress/integration/debtpaybacks/form_submission.js
@@ -72,7 +72,7 @@ describe('Debt Payback Form Tests', () => {
       .find('input')
       .type('2019-04-28');
     cy.get('form')
-      .contains('occurences')
+      .contains('occurrences')
       .parent()
       .parent()
       .find('input')

--- a/src/pages/accounts/barChart.js
+++ b/src/pages/accounts/barChart.js
@@ -396,7 +396,7 @@ barBuild.drawBar = function(
   let color = d =>
     d3
       .scaleLinear()
-      .domain([0, 1])
+      .domain([0, massagedData.length])
       .range(colors(d));
 
   // Add a group for each entry

--- a/src/pages/flow/accountTransactionInput.js
+++ b/src/pages/flow/accountTransactionInput.js
@@ -24,7 +24,7 @@ class AccountTransactionInput extends React.Component {
                   start: '',
                   rtype: 'none',
                   cycle: 0,
-                  occurences: 0,
+                  occurrences: 0,
                   value: 0,
                   ...model.forms.accountTransactionForm.state
                 }}
@@ -145,21 +145,21 @@ class AccountTransactionInput extends React.Component {
                     </div>
                     <div className="field is-horizontal">
                       <div className="field-label is-normal">
-                        <label className="label">occurences</label>
+                        <label className="label">occurrences</label>
                       </div>
                       <div className="field-body">
                         <div className="field">
                           <p className="control">
                             <Field
                               type="number"
-                              name="occurences"
+                              name="occurrences"
                               className="input"
                             />
                           </p>
                         </div>
                       </div>
-                      {touched.occurences && errors.occurences && (
-                        <div>{errors.occurences}</div>
+                      {touched.occurrences && errors.occurrences && (
+                        <div>{errors.occurrences}</div>
                       )}
                     </div>
                     <div className="field is-horizontal">

--- a/src/pages/flow/barChart.js
+++ b/src/pages/flow/barChart.js
@@ -399,7 +399,7 @@ barBuild.drawBar = function(
   let color = d =>
     d3
       .scaleLinear()
-      .domain([0, 1])
+      .domain([0, massagedData.length])
       .range(colors(d));
 
   // Add a group for each entry

--- a/src/pages/flow/transactionInput.js
+++ b/src/pages/flow/transactionInput.js
@@ -136,7 +136,7 @@ class TransactionInput extends React.Component {
 
                   <FieldInput
                     errors={errors}
-                    fieldName="occurences"
+                    fieldName="occurrences"
                     touched={touched}
                     fieldType="number"
                   />

--- a/src/state/forms.js
+++ b/src/state/forms.js
@@ -55,7 +55,7 @@ class AccountTransactionForm {
   start = StringType;
   rtype = StringType;
   cycle = create(Big, 0);
-  occurences = create(Big, 0);
+  occurrences = create(Big, 0);
   value = create(Big, 0);
 
   get state() {

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -309,7 +309,7 @@ class AppModel {
       start: result.start,
       rtype: result.rtype,
       cycle: result.cycle,
-      occurences: result.occurences,
+      occurrences: result.occurrences,
       value: result.value
     };
 

--- a/src/state/index.js
+++ b/src/state/index.js
@@ -207,7 +207,7 @@ class AppModel {
       const { accounts } = this.state;
       computeAccounts = accounts.map(account => {
         let computed = account;
-        computed.visible = true;
+        if (computed && computed.visible === undefined) computed.visible = true;
         return computed;
       });
     } else {

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -42,10 +42,6 @@ const coercePaybacks = ({ accounts }) => {
           // but mathed as negative so it will reduce the
           // balance of a debt (which is entered as a positive number)
           // where transfers (for credit line) need to be explicitly negative
-          let amount =
-            typeof accountTransaction.value === 'string'
-              ? account.payback[accountTransaction.value]
-              : accountTransaction.value;
           transactions.push({
             ...accountTransaction,
             id: `${accountTransaction.id}-${index}EXP`,
@@ -54,16 +50,15 @@ const coercePaybacks = ({ accounts }) => {
               account.payback.description || accountTransaction.description,
             type: account.vehicle === 'credit line' ? 'transfer' : 'expense',
             category: account.payback.category || accountTransaction.category,
-            value: account.vehicle === 'credit line' ? -amount : amount,
+            value:
+              account.vehicle === 'credit line'
+                ? -accountTransaction.value
+                : accountTransaction.value,
             fromAccount: true
           });
+
           // this one is for the account making the payment
           // (raccount is defined on accountTransaction)
-          // negative transfer don't show up on the bar chart
-          // but they should affect the math of, say, the line chart
-          // we can use this to avoid visual duplication of two
-          // transactions for the same amount reducing the balance
-          // on two different accounts
           transactions.push({
             ...accountTransaction,
             id: `${accountTransaction.id}-${index}TRSF`,
@@ -71,7 +66,7 @@ const coercePaybacks = ({ accounts }) => {
               account.payback.description || accountTransaction.description,
             type: 'transfer',
             category: account.payback.category || accountTransaction.category,
-            value: -amount,
+            value: -accountTransaction.value,
             fromAccount: true
           });
         });

--- a/src/state/resolveFinancials/index.js
+++ b/src/state/resolveFinancials/index.js
@@ -50,9 +50,10 @@ const coercePaybacks = ({ accounts }) => {
             ...accountTransaction,
             id: `${accountTransaction.id}-${index}EXP`,
             raccount: account.name,
-            description: account.payback.description,
+            description:
+              account.payback.description || accountTransaction.description,
             type: account.vehicle === 'credit line' ? 'transfer' : 'expense',
-            category: account.payback.category,
+            category: account.payback.category || accountTransaction.category,
             value: account.vehicle === 'credit line' ? -amount : amount,
             fromAccount: true
           });
@@ -66,9 +67,10 @@ const coercePaybacks = ({ accounts }) => {
           transactions.push({
             ...accountTransaction,
             id: `${accountTransaction.id}-${index}TRSF`,
-            description: account.payback.description,
+            description:
+              account.payback.description || accountTransaction.description,
             type: 'transfer',
-            category: account.payback.category,
+            category: account.payback.category || accountTransaction.category,
             value: -amount,
             fromAccount: true
           });

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -123,7 +123,7 @@ describe(`check state creation`, () => {
 });
 
 describe(`check integrated transaction reoccurence`, () => {
-  it(`returns the correct number of daily reoccurences`, () => {
+  it(`returns the correct number of daily reoccurrences`, () => {
     let singleTransaction = resolvedTestData.transactions
       .set([
         {
@@ -151,14 +151,14 @@ describe(`check integrated transaction reoccurence`, () => {
     // beginning on Feb 4th, 2018, but the graphrange doesn't
     // start until March 1st, 2018. This means the first time it
     // shows up should be on March 4th. This will mean we have
-    // 13 total occurences of the transaction in our range.
+    // 13 total occurrences of the transaction in our range.
     // (The 14th lands on Sept 2nd.) If we erroneously show the
     // first occurence at the beginning of the graphrange, which
-    // is 3 days earlier, we would see 14 occurences instead.
+    // is 3 days earlier, we would see 14 occurrences instead.
 
     // the max with a single transaction should === value of that transaction
     expect(singleTransaction.charts.state.BarChartMax).toEqual(1200);
-    // the max should be our 13 occurences * value + starting ($0 here)
+    // the max should be our 13 occurrences * value + starting ($0 here)
     // that is: 13 * 1200 = 15600
     expect(singleTransaction.charts.state.LineChartMax).toEqual(15600);
   });
@@ -207,13 +207,13 @@ describe(`check integrated transaction reoccurence`, () => {
 
     const count = singleTransaction.charts.state.AccountChart[0].values.length;
     // if 52 occurrences in a year, and we missed 8 at the beginning of the range
-    // the max should be our starting - 44 occurences * value = 800
+    // the max should be our starting - 44 occurrences * value = 800
     expect(
       singleTransaction.charts.state.AccountChart[0].values[count - 1].value
     ).toEqual(800);
   });
 
-  it(`returns the correct number of semiannual reoccurences`, () => {
+  it(`returns the correct number of semiannual reoccurrences`, () => {
     let singleTransaction = resolvedTestData.transactions
       .set([
         {
@@ -240,7 +240,7 @@ describe(`check integrated transaction reoccurence`, () => {
     // This should occur twice a year beginning on Feb 4th, 2019,
     // but the graphrange doesn't start until March 1st, 2019.
     // This means the first time it shows up should be on July 4th.
-    // This will mean we have 2 total occurences of the transaction in
+    // This will mean we have 2 total occurrences of the transaction in
     // our range every time if we look at a 365 day year.
 
     // the max with a single transaction should === value of that transaction
@@ -253,7 +253,7 @@ describe(`check integrated transaction reoccurence`, () => {
     });
 
     const count = singleTransaction.charts.state.AccountChart[0].values.length;
-    // the max should be our starting - 2 occurences * value = 0
+    // the max should be our starting - 2 occurrences * value = 0
     expect(
       singleTransaction.charts.state.AccountChart[0].values[count - 1].value
     ).toEqual(0);
@@ -305,7 +305,7 @@ describe(`check integrated transaction reoccurence`, () => {
     });
 
     const count = singleTransaction.charts.state.AccountChart[0].values.length;
-    // the max should be our starting - 2 occurences * value = 2000
+    // the max should be our starting - 2 occurrences * value = 2000
     expect(
       singleTransaction.charts.state.AccountChart[0].values[count - 1].value
     ).toEqual(2000);

--- a/src/state/resolveFinancials/resolveTransactions/index.js
+++ b/src/state/resolveFinancials/resolveTransactions/index.js
@@ -197,10 +197,10 @@ const transactionDailyReoccur = ({ transaction, seedDate, occurrences }) => {
   // the next date should be a multiple of the cycle, so divide by the cycle
   // then round up (0 decimal places, 3 round up) then multiply by cycle again
   // to give us the number of days to add to the transaction start date to
-  // produce an occurence on/after the seedDate. If there are no occurences
+  // produce an occurence on/after the seedDate. If there are no occurrences
   // yet, we are looking for the first date and we want a date on/after the seedDate.
-  // If we have any occurences, then seedDate will actually be the date of the
-  // last occurences so we add the cycle to that to get the next occurence.
+  // If we have any occurrences, then seedDate will actually be the date of the
+  // last occurrences so we add the cycle to that to get the next occurence.
   const cycle = Big(differenceInCalendarDays(transaction.start)(seedDate))
     .div(transaction.cycle)
     .round(0, 3)
@@ -365,10 +365,10 @@ const transactionSemiannuallyReoccur = ({
   // the next date should be a multiple of the 6 months, so divide by the 6
   // then round up (0 decimal places, 3 round up) then multiply by 6 again
   // to give us the number of months to add to the transaction start date to
-  // produce an occurence on/after the seedDate. If there are no occurences
+  // produce an occurence on/after the seedDate. If there are no occurrences
   // yet, we are looking for the first date and we want a date on/after the seedDate.
-  // If we have any occurences, then seedDate will actually be the date of the
-  // last occurences so we add 6 to that to get the next occurence.
+  // If we have any occurrences, then seedDate will actually be the date of the
+  // last occurrences so we add 6 to that to get the next occurence.
   const monthDifference = Big(
     differenceInCalendarMonths(transaction.start)(seedDate)
   )
@@ -406,10 +406,10 @@ const transactionAnnuallyReoccur = ({ transaction, seedDate, occurrences }) => {
   // Finds how many months are between when this started and the date in question
   // then round up (0 decimal places, 3 round up) to give us the number of years
   // to add to the transaction start date to produce an occurence on/after
-  // the seedDate. If there are no occurences yet, we are looking for
+  // the seedDate. If there are no occurrences yet, we are looking for
   // the first date and we want a date on/after the seedDate. If we have
-  // any occurences, then seedDate will actually be the date of the
-  // last occurences so we add 1 to that to get the next occurence.
+  // any occurrences, then seedDate will actually be the date of the
+  // last occurrences so we add 1 to that to get the next occurence.
   const yearDifference = Big(
     differenceInCalendarYears(transaction.start)(seedDate)
   )

--- a/src/state/resolveFinancials/resolveTransactions/transactionDayOfMonthReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionDayOfMonthReoccur.test.js
@@ -167,7 +167,7 @@ describe(`check transactionDayOfMonthReoccur`, () => {
     expect(resolvedTestData2).toHaveLength(7);
   });
 
-  it(`returns correct number of modifications based on generated occurences`, () => {
+  it(`returns correct number of modifications based on generated occurrences`, () => {
     let testData1 = {
       ...transaction,
       id: `${transaction.id} genOc`,
@@ -199,7 +199,7 @@ describe(`check transactionDayOfMonthReoccur`, () => {
     expect(resolvedTestData2).toHaveLength(2);
   });
 
-  it(`returns correct number of modifications based on visible occurences`, () => {
+  it(`returns correct number of modifications based on visible occurrences`, () => {
     let testData1 = {
       ...transaction,
       start: graphRange.start,

--- a/src/state/resolveFinancials/seedData.js
+++ b/src/state/resolveFinancials/seedData.js
@@ -47,7 +47,7 @@ let seedOne = {
       start: `2018-03-22`,
       rtype: `day`,
       cycle: 3,
-      generatedOccurences: 0,
+      generatedOccurrences: 0,
       value: 150
     }
   }
@@ -73,10 +73,10 @@ let seedTwo = {
       id: `oasis2`,
       raccount: `account`,
       description: `description`,
-      category: `test default occurences`,
+      category: `test default occurrences`,
       type: `income`,
       start: `2018-09-22`,
-      occurences: 7,
+      occurrences: 7,
       rtype: `day`,
       cycle: 1,
       value: 100

--- a/src/state/transactions.js
+++ b/src/state/transactions.js
@@ -73,8 +73,13 @@ class TransactionComputed extends Transaction {
 
   computeValue() {
     if (!!this.computedAmount.state && this.computedAmount.state.references) {
+      // it is kind of janky to use the value's positive/negative sign on
+      // the computed value, but that is how coercePaybacks communicates
+      // that it is a transfer or not. Might be worth thinking about this more
+      // and refactoring to credit/debit style instead
+
       // compute should return a non-microstate number
-      return this.value.set(this.computedAmount.compute);
+      return this.value.set(this.value.state.s * this.computedAmount.compute);
     } else {
       return this;
     }


### PR DESCRIPTION
Tests and tweaks to make sure credit cards with multiple transactions are working as expected.

The last bit of this should come in #79. The occurrences appear to be able to cover all the required use cases. (Don't forget about `beginAfterOccurrences` which doesn't yet show up in any form.) #79 should help pull values from the account from which we can use to compute a value.