### PR TITLE
Parse date strings

### DIFF
--- a/src/state/app.test.js
+++ b/src/state/app.test.js
@@ -1,12 +1,13 @@
 import { create } from 'microstates';
 import AppModel from './../state';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { testData } from './resolveFinancials/index.testdata.js';
 
 let graphRange = {
-  start: startOfDay('2018-03-01'),
-  end: startOfDay('2018-09-01')
+  start: startOfDay(parseISO('2018-03-01')),
+  end: startOfDay(parseISO('2018-09-01'))
 };
 testData.charts = {};
 testData.charts.GraphRange = graphRange;

--- a/src/state/charts.js
+++ b/src/state/charts.js
@@ -79,7 +79,6 @@ class Charts extends Primitive {
   }
 
   calcBarCharts(transactionsSplit) {
-    const parsedGraphRange = { start: parseISO(), end: parseISO() };
     let income = resolveBarChart(transactionsSplit.income, {
       graphRange: this.state.GraphRange
     });

--- a/src/state/charts.js
+++ b/src/state/charts.js
@@ -14,6 +14,7 @@ import {
   resolveAccountChart
 } from './resolveFinancials';
 import format from 'date-fns/fp/format';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 import addDays from 'date-fns/fp/addDays';
 const addYear = addDays(365);
@@ -65,10 +66,10 @@ class Charts extends Primitive {
   }
 
   updateStartDate(start, end) {
-    const startDate = startOfDay(start);
+    const startDate = startOfDay(parseISO(start));
     const graphRange = {
       start: startDate,
-      end: !!end ? startOfDay(end) : addYear(start)
+      end: !!end ? startOfDay(parseISO(end)) : addYear(parseISO(start))
     };
     return this.GraphRange.set(graphRange);
   }
@@ -78,6 +79,7 @@ class Charts extends Primitive {
   }
 
   calcBarCharts(transactionsSplit) {
+    const parsedGraphRange = { start: parseISO(), end: parseISO() };
     let income = resolveBarChart(transactionsSplit.income, {
       graphRange: this.state.GraphRange
     });

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -201,11 +201,11 @@ describe(`check integrated transaction reoccurence`, () => {
 
     const values = singleTransaction.charts.state.AccountChart[0].values;
     expect(values[132]).toEqual({
-      date: startOfDay('2019-05-06'),
+      date: startOfDay(parseISO('2019-05-06')),
       value: 2950
     });
     expect(values[188]).toEqual({
-      date: startOfDay('2019-06-03'),
+      date: startOfDay(parseISO('2019-06-03')),
       value: 2750
     });
 
@@ -252,7 +252,7 @@ describe(`check integrated transaction reoccurence`, () => {
     expect(singleTransaction.charts.state.LineChartMax).toEqual(2400);
 
     expect(singleTransaction.charts.state.AccountChart[0].values[312]).toEqual({
-      date: startOfDay('2019-08-04'),
+      date: startOfDay(parseISO('2019-08-04')),
       value: 1200
     });
 
@@ -300,11 +300,11 @@ describe(`check integrated transaction reoccurence`, () => {
     expect(singleTransaction.charts.state.LineChartMax).toEqual(12000);
 
     expect(singleTransaction.charts.state.AccountChart[0].values[128]).toEqual({
-      date: startOfDay('2019-05-04'),
+      date: startOfDay(parseISO('2019-05-04')),
       value: 7000
     });
     expect(singleTransaction.charts.state.AccountChart[0].values[860]).toEqual({
-      date: startOfDay('2020-05-04'),
+      date: startOfDay(parseISO('2020-05-04')),
       value: 2000
     });
 

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -340,10 +340,11 @@ describe(`check resolveData handles paybacks`, () => {
     revisedTestData.transactions = [];
     let resolvedTestData = create(AppModel, revisedTestData).reCalc();
 
-    // that is 163 days between start and end
-    // 164*$140 + 164/3*$60 + (1) extra $60 = 22960 + 3240 + 60 = 26260
+    // that is 163 days between start and end, 185 days in our full range
+    // 163*$140 + 164/3*$60 + (1) extra $60 = 22820 + 3240 + 60 = 26260
     const count =
       resolvedTestData.charts.state.AccountChart[0].values.length - 1;
+    expect(count).toEqual(185 * 2 - 1);
     // this tests the transfer, which reduces the balance of the payment account
     // $3000 starting - 26260 = -23260
     expect(

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -472,7 +472,7 @@ describe('check AccountChart', () => {
   it('outputs an empty array if values is empty', () => {
     let accounts = [{ name: 'test1' }, { name: 'test2' }];
     let incomeRaw = [
-      { raccount: 'test1', start: graphRange.start, value: Big(10) }
+      { raccount: 'test1', start: '2018-03-01', value: Big(10) }
     ];
     let income = resolveBarChart(incomeRaw, { graphRange });
     let expense = [];

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -341,7 +341,7 @@ describe(`check resolveData handles paybacks`, () => {
     let resolvedTestData = create(AppModel, revisedTestData).reCalc();
 
     // that is 163 days between start and end, 185 days in our full range
-    // 163*$140 + 164/3*$60 + (1) extra $60 = 22820 + 3240 + 60 = 26260
+    // 164*$140 + 164/3*$60 + (1) extra $60 = 22960 + 3240 + 60 = 26260
     const count =
       resolvedTestData.charts.state.AccountChart[0].values.length - 1;
     expect(count).toEqual(185 * 2 - 1);

--- a/src/state/resolveFinancials/index.test.js
+++ b/src/state/resolveFinancials/index.test.js
@@ -8,6 +8,7 @@ import {
 } from './index.js';
 import computeTransactionModifications from './resolveTransactions';
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 import eachDayOfInterval from 'date-fns/fp/eachDayOfInterval';
 import format from 'date-fns/fp/format';
@@ -17,8 +18,8 @@ import { testData, testData2 } from './index.testdata.js';
 const formatDate = format('yyyy-MM-dd kkmmss');
 
 let graphRange = {
-  start: startOfDay('2018-03-01'),
-  end: startOfDay('2018-09-01')
+  start: startOfDay(parseISO('2018-03-01')),
+  end: startOfDay(parseISO('2018-09-01'))
 };
 testData.charts = {};
 testData.charts.GraphRange = graphRange;

--- a/src/state/resolveFinancials/resolveBarChart.test.js
+++ b/src/state/resolveFinancials/resolveBarChart.test.js
@@ -1,6 +1,7 @@
 import { resolveBarChart } from './index.js';
-import startOfDay from 'date-fns/fp/startOfDay';
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
+import startOfDay from 'date-fns/fp/startOfDay';
 
 const testData = {
   transactions: [
@@ -22,8 +23,8 @@ const testData = {
 describe(`check resolveBarChart`, () => {
   it(`has all the correct original properties`, () => {
     let graphRange = {
-      start: startOfDay('2018-01-01'),
-      end: startOfDay('2019-01-01')
+      start: startOfDay(parseISO('2018-01-01')),
+      end: startOfDay(parseISO('2019-01-01'))
     };
     let resolvedTestData = resolveBarChart(testData.transactions, {
       graphRange
@@ -42,8 +43,8 @@ describe(`check resolveBarChart`, () => {
 
   it(`has the new properties`, () => {
     let graphRange = {
-      start: startOfDay('2018-01-01'),
-      end: startOfDay('2018-02-01')
+      start: startOfDay(parseISO('2018-01-01')),
+      end: startOfDay(parseISO('2018-02-01'))
     };
     let resolvedTestData = resolveBarChart(testData.transactions, {
       graphRange

--- a/src/state/resolveFinancials/resolveTransactions/index.js
+++ b/src/state/resolveFinancials/resolveTransactions/index.js
@@ -256,13 +256,13 @@ const transactionDayOfWeekReoccur = ({
 
   const parsedStartDate = parseISO(transaction.start);
   const seedDay = getDay(seedDate);
-  const startDay = getDay(transaction.start);
+  const startDay = getDay(parsedStartDate);
   const dayAdjust = transaction.cycle.gte(seedDay)
     ? transaction.cycle.minus(seedDay)
     : transaction.cycle.minus(seedDay).plus(7);
 
-  const dayCycles = isBefore(seedDate)(transaction.start)
-    ? Big(differenceInCalendarDays(transaction.start)(seedDate))
+  const dayCycles = isBefore(seedDate)(parsedStartDate)
+    ? Big(differenceInCalendarDays(parsedStartDate)(seedDate))
         .plus(dayAdjust)
         .div(7)
         .round(0, 3)
@@ -272,7 +272,7 @@ const transactionDayOfWeekReoccur = ({
     : transaction.cycle.minus(startDay).plus(7);
 
   return {
-    date: addDays(dayCycles)(transaction.start),
+    date: addDays(dayCycles)(parsedStartDate),
     y: transaction.value
   };
 };

--- a/src/state/resolveFinancials/resolveTransactions/index.js
+++ b/src/state/resolveFinancials/resolveTransactions/index.js
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import dateMax from 'date-fns/fp/max';
 import dateMin from 'date-fns/fp/min';
 import isWithinInterval from 'date-fns/fp/isWithinInterval';
@@ -19,7 +20,12 @@ const computeTransactionModifications = (transactions, graphRange) =>
   transactions.reduce((modifications, transaction) => {
     let transactionInterval = convertRangeToInterval(transaction, graphRange);
     // early return if end is before start, we will have no modifications
-    if (isBefore(transactionInterval.start)(transactionInterval.end)) return [];
+    if (
+      isBefore(parseISO(transactionInterval.start))(
+        parseISO(transactionInterval.end)
+      )
+    )
+      return [];
 
     // and if the value is positive, generate the necessary mods
     return modifications.concat(
@@ -39,12 +45,12 @@ export default computeTransactionModifications;
 const convertRangeToInterval = (transaction, graphRange) => ({
   start: dateMax([
     graphRange.start,
-    !!transaction && transaction.start ? transaction.start : 0
+    !!transaction && transaction.start ? parseISO(transaction.start) : 0
   ]),
   end: dateMin([
     graphRange.end,
     !!transaction && transaction.end
-      ? transaction.end
+      ? parseISO(transaction.end)
       : addDays(365)(new Date())
   ])
 });
@@ -172,7 +178,7 @@ const transactionNoReoccur = ({ transaction, seedDate }) => {
   }
 
   return {
-    date: transaction.start,
+    date: parseISO(transaction.start),
     y: transaction.value
   };
 };
@@ -201,14 +207,15 @@ const transactionDailyReoccur = ({ transaction, seedDate, occurrences }) => {
   // yet, we are looking for the first date and we want a date on/after the seedDate.
   // If we have any occurrences, then seedDate will actually be the date of the
   // last occurrences so we add the cycle to that to get the next occurence.
-  const cycle = Big(differenceInCalendarDays(transaction.start)(seedDate))
+  const parsedStartDate = parseISO(transaction.start);
+  const cycle = Big(differenceInCalendarDays(parsedStartDate)(seedDate))
     .div(transaction.cycle)
     .round(0, 3)
     .times(transaction.cycle)
     .plus(occurrences.eq(0) ? 0 : transaction.cycle);
 
   return {
-    date: addDays(cycle)(transaction.start),
+    date: addDays(cycle)(parsedStartDate),
     y: transaction.value
   };
 };
@@ -247,6 +254,7 @@ const transactionDayOfWeekReoccur = ({
   // to the transaction start date that will return a day after the
   // seedDate and that lands on our required day of the week.
 
+  const parsedStartDate = parseISO(transaction.start);
   const seedDay = getDay(seedDate);
   const startDay = getDay(transaction.start);
   const dayAdjust = transaction.cycle.gte(seedDay)
@@ -369,20 +377,21 @@ const transactionSemiannuallyReoccur = ({
   // yet, we are looking for the first date and we want a date on/after the seedDate.
   // If we have any occurrences, then seedDate will actually be the date of the
   // last occurrences so we add 6 to that to get the next occurence.
+  const parsedStartDate = parseISO(transaction.start);
   const monthDifference = Big(
-    differenceInCalendarMonths(transaction.start)(seedDate)
+    differenceInCalendarMonths(parsedStartDate)(seedDate)
   )
     .div(6)
     .round(0, 3)
     .times(6)
     .plus(occurrences.eq(0) ? 0 : 6);
   const afterSeed = isAfter(seedDate);
-  const increment = afterSeed(addMonths(monthDifference)(transaction.start))
+  const increment = afterSeed(addMonths(monthDifference)(parsedStartDate))
     ? 0
     : 6;
 
   return {
-    date: addMonths(monthDifference.plus(increment))(transaction.start),
+    date: addMonths(monthDifference.plus(increment))(parsedStartDate),
     y: transaction.value
   };
 };
@@ -410,14 +419,15 @@ const transactionAnnuallyReoccur = ({ transaction, seedDate, occurrences }) => {
   // the first date and we want a date on/after the seedDate. If we have
   // any occurrences, then seedDate will actually be the date of the
   // last occurrences so we add 1 to that to get the next occurence.
+  const parsedStartDate = parseISO(transaction.start);
   const yearDifference = Big(
-    differenceInCalendarYears(transaction.start)(seedDate)
+    differenceInCalendarYears(parsedStartDate)(seedDate)
   )
     .round(0, 3)
     .plus(occurrences.eq(0) ? 0 : 1);
 
   return {
-    date: addYears(yearDifference)(transaction.start),
+    date: addYears(yearDifference)(parsedStartDate),
     y: transaction.value
   };
 };

--- a/src/state/resolveFinancials/resolveTransactions/index.js
+++ b/src/state/resolveFinancials/resolveTransactions/index.js
@@ -42,18 +42,26 @@ const computeTransactionModifications = (transactions, graphRange) =>
 
 export default computeTransactionModifications;
 
-const convertRangeToInterval = (transaction, graphRange) => ({
-  start: dateMax([
+const convertRangeToInterval = (transaction, graphRange) => {
+  const startDate = dateMax([
     graphRange.start,
     !!transaction && transaction.start ? parseISO(transaction.start) : 0
-  ]),
-  end: dateMin([
-    graphRange.end,
-    !!transaction && transaction.end
-      ? parseISO(transaction.end)
-      : addDays(365)(new Date())
-  ])
-});
+  ]);
+  // the endDate always has to be equal to or after startDate
+  const endDate = dateMax([
+    startDate,
+    dateMin([
+      graphRange.end,
+      !!transaction && transaction.end
+        ? parseISO(transaction.end)
+        : addDays(365)(new Date())
+    ])
+  ]);
+  return {
+    start: startDate,
+    end: endDate
+  };
+};
 
 export { convertRangeToInterval };
 

--- a/src/state/resolveFinancials/resolveTransactions/index.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/index.test.js
@@ -1,3 +1,4 @@
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { convertRangeToInterval } from './index.js';
@@ -6,44 +7,44 @@ describe(`check convertRangeToInterval`, () => {
   it(`returns range start shifted forward`, () => {
     const transaction = { start: `2018-03-22` };
     let graphRange = {
-      start: startOfDay('2018-01-01'),
-      end: startOfDay('2018-06-01')
+      start: startOfDay(parseISO('2018-01-01')),
+      end: startOfDay(parseISO('2018-06-01'))
     };
     let interval = convertRangeToInterval(transaction, graphRange);
-    expect(interval.start).toEqual(startOfDay('2018-03-22'));
-    expect(interval.end).toEqual(startOfDay('2018-06-01'));
+    expect(interval.start).toEqual(startOfDay(parseISO('2018-03-22')));
+    expect(interval.end).toEqual(startOfDay(parseISO('2018-06-01')));
   });
 
   it(`returns range start before`, () => {
     const transaction = { start: `2017-08-01` };
     let graphRange = {
-      start: startOfDay('2018-01-15'),
-      end: startOfDay('2018-06-01')
+      start: startOfDay(parseISO('2018-01-15')),
+      end: startOfDay(parseISO('2018-06-01'))
     };
     let interval = convertRangeToInterval(transaction, graphRange);
-    expect(interval.start).toEqual(startOfDay('2018-01-15'));
-    expect(interval.end).toEqual(startOfDay('2018-06-01'));
+    expect(interval.start).toEqual(startOfDay(parseISO('2018-01-15')));
+    expect(interval.end).toEqual(startOfDay(parseISO('2018-06-01')));
   });
 
   it(`returns range end shifted back`, () => {
     const transaction = { start: `2018-03-22`, end: '2018-05-02' };
     let graphRange = {
-      start: startOfDay('2018-01-01'),
-      end: startOfDay('2018-06-01')
+      start: startOfDay(parseISO('2018-01-01')),
+      end: startOfDay(parseISO('2018-06-01'))
     };
     let interval = convertRangeToInterval(transaction, graphRange);
-    expect(interval.start).toEqual(startOfDay('2018-03-22'));
-    expect(interval.end).toEqual(startOfDay('2018-05-02'));
+    expect(interval.start).toEqual(startOfDay(parseISO('2018-03-22')));
+    expect(interval.end).toEqual(startOfDay(parseISO('2018-05-02')));
   });
 
   it(`returns range end after`, () => {
     const transaction = { start: `2017-08-22`, end: '2018-08-02' };
     let graphRange = {
-      start: startOfDay('2018-01-15'),
-      end: startOfDay('2018-06-01')
+      start: startOfDay(parseISO('2018-01-15')),
+      end: startOfDay(parseISO('2018-06-01'))
     };
     let interval = convertRangeToInterval(transaction, graphRange);
-    expect(interval.start).toEqual(startOfDay('2018-01-15'));
-    expect(interval.end).toEqual(startOfDay('2018-06-01'));
+    expect(interval.start).toEqual(startOfDay(parseISO('2018-01-15')));
+    expect(interval.end).toEqual(startOfDay(parseISO('2018-06-01')));
   });
 });

--- a/src/state/resolveFinancials/resolveTransactions/transactionAnnuallyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionAnnuallyReoccur.test.js
@@ -1,23 +1,24 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { transactionAnnuallyReoccur } from './index.js';
 
 describe('transactionAnnuallyReoccur', () => {
   it('has the next date', () => {
-    const transaction = { start: startOfDay('2018-01-01'), value: Big(365) };
-    const seedDate = startOfDay('2018-01-01');
+    const transaction = { start: '2018-01-01', value: Big(365) };
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionAnnuallyReoccur({
       transaction,
       seedDate,
       occurrences: Big(1)
     });
-    expect(next.date).toEqual(startOfDay('2019-01-01'));
+    expect(next.date).toEqual(startOfDay(parseISO('2019-01-01')));
   });
 
   it('has a value', () => {
-    const transaction = { start: startOfDay('2018-01-01'), value: Big(365) };
-    const seedDate = startOfDay('2018-01-01');
+    const transaction = { start: '2018-01-01', value: Big(365) };
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionAnnuallyReoccur({
       transaction,
       seedDate,
@@ -27,10 +28,10 @@ describe('transactionAnnuallyReoccur', () => {
   });
 
   it('throws on missing value', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionAnnuallyReoccur({
-        transaction: { start: startOfDay('2018-01-01') },
+        transaction: { start: '2018-01-01' },
         seedDate,
         occurrences: Big(0)
       });
@@ -38,7 +39,7 @@ describe('transactionAnnuallyReoccur', () => {
   });
 
   it('throws on missing start', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionAnnuallyReoccur({
         transaction: { value: Big(120) },
@@ -49,17 +50,17 @@ describe('transactionAnnuallyReoccur', () => {
   });
 
   it('throws on missing occurrences', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionAnnuallyReoccur({
-        transaction: { start: startOfDay('2018-01-01'), value: Big(120) },
+        transaction: { start: '2018-01-01', value: Big(120) },
         seedDate
       });
     }).toThrow();
   });
 
   it('fails if transaction is null', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionAnnuallyReoccur({ transaction: null, seedDate });
     }).toThrow();

--- a/src/state/resolveFinancials/resolveTransactions/transactionBimonthlyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionBimonthlyReoccur.test.js
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { transactionBimonthlyReoccur } from './index.js';
@@ -6,17 +7,17 @@ import { transactionBimonthlyReoccur } from './index.js';
 describe('transactionBimonthlyReoccur', () => {
   it('has the next date', () => {
     const transaction = { value: Big(10), cycle: Big(1) };
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionBimonthlyReoccur({
       transaction,
       seedDate
     });
-    expect(next.date).toEqual(startOfDay('2018-03-01'));
+    expect(next.date).toEqual(startOfDay(parseISO('2018-03-01')));
   });
 
   it('throws when cycle=null', () => {
     const transaction = { value: Big(10) };
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionBimonthlyReoccur({
         transaction,
@@ -26,7 +27,7 @@ describe('transactionBimonthlyReoccur', () => {
   });
 
   it('throws on missing value', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionBimonthlyReoccur({
         transaction: {},
@@ -37,17 +38,17 @@ describe('transactionBimonthlyReoccur', () => {
 
   it('calculates a cycle of 2 (4 months)', () => {
     const transaction = { value: Big(10), cycle: Big(2) };
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionBimonthlyReoccur({
       transaction,
       seedDate
     });
-    expect(next.date).toEqual(startOfDay('2018-05-01'));
+    expect(next.date).toEqual(startOfDay(parseISO('2018-05-01')));
   });
 
   it('has a value', () => {
     const transaction = { value: Big(10), cycle: Big(1) };
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionBimonthlyReoccur({
       transaction,
       seedDate
@@ -56,7 +57,7 @@ describe('transactionBimonthlyReoccur', () => {
   });
 
   it('fails if transaction is null', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionBimonthlyReoccur({ transaction: null, seedDate });
     }).toThrow();

--- a/src/state/resolveFinancials/resolveTransactions/transactionDailyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionDailyReoccur.test.js
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 import differenceInCalendarDays from 'date-fns/fp/differenceInDays';
 import getDate from 'date-fns/fp/getDate';
@@ -20,8 +21,8 @@ describe(`check transactionDailyReoccur`, () => {
     value: Big(150)
   };
   let graphRange = {
-    start: startOfDay('2018-03-01'),
-    end: startOfDay('2018-06-01')
+    start: startOfDay(parseISO('2018-03-01')),
+    end: startOfDay(parseISO('2018-06-01'))
   };
   let interval = convertRangeToInterval(transaction, graphRange);
   let seedDate = interval.start;
@@ -67,7 +68,9 @@ describe(`check transactionDailyReoccur`, () => {
       occurrences: Big(1)
     });
     expect(
-      differenceInCalendarDays(transaction.start)(secondIteration.date)
+      differenceInCalendarDays(parseISO(transaction.start))(
+        secondIteration.date
+      )
     ).toBe(1);
   });
 
@@ -91,7 +94,9 @@ describe(`check transactionDailyReoccur`, () => {
       occurrences: Big(1)
     });
     expect(
-      differenceInCalendarDays(transaction.start)(secondIteration.date)
+      differenceInCalendarDays(parseISO(transaction.start))(
+        secondIteration.date
+      )
     ).toBe(3);
   });
 
@@ -115,7 +120,9 @@ describe(`check transactionDailyReoccur`, () => {
       occurrences: Big(1)
     });
     expect(
-      differenceInCalendarDays(transaction.start)(secondIteration.date)
+      differenceInCalendarDays(parseISO(transaction.start))(
+        secondIteration.date
+      )
     ).toBe(5);
   });
 
@@ -139,7 +146,9 @@ describe(`check transactionDailyReoccur`, () => {
       occurrences: Big(1)
     });
     expect(
-      differenceInCalendarDays(transaction.start)(secondIteration.date)
+      differenceInCalendarDays(parseISO(transaction.start))(
+        secondIteration.date
+      )
     ).toBe(14);
   });
 });

--- a/src/state/resolveFinancials/resolveTransactions/transactionDayOfMonthReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionDayOfMonthReoccur.test.js
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 import differenceInCalendarDays from 'date-fns/fp/differenceInDays';
 
@@ -20,8 +21,8 @@ describe(`check transactionDayOfMonthReoccur`, () => {
     value: Big(150)
   };
   let graphRange = {
-    start: startOfDay('2018-01-16'),
-    end: startOfDay('2018-04-01')
+    start: startOfDay(parseISO('2018-01-16')),
+    end: startOfDay(parseISO('2018-04-01'))
   };
   let seedDate = graphRange.start;
   let occurrences = Big(0);
@@ -147,8 +148,8 @@ describe(`check transactionDayOfMonthReoccur`, () => {
       value: Big(150)
     };
     let testRange = {
-      start: startOfDay('2018-01-16'),
-      end: startOfDay('2018-08-01')
+      start: startOfDay(parseISO('2018-01-16')),
+      end: startOfDay(parseISO('2018-08-01'))
     };
     let resolvedTestData1 = generateModification(
       testData,
@@ -175,7 +176,10 @@ describe(`check transactionDayOfMonthReoccur`, () => {
       cycle: 17,
       occurrences: Big(1)
     };
-    let testRange = { start: graphRange.start, end: '2018-12-01' };
+    let testRange = {
+      start: graphRange.start,
+      end: startOfDay(parseISO('2018-12-01'))
+    };
 
     let resolvedTestData1 = generateModification(
       testData1,
@@ -206,7 +210,10 @@ describe(`check transactionDayOfMonthReoccur`, () => {
       cycle: 17,
       occurrences: 1
     };
-    let testRange = { start: graphRange.start, end: '2018-12-01' };
+    let testRange = {
+      start: graphRange.start,
+      end: startOfDay(parseISO('2018-12-01'))
+    };
 
     let resolvedTestData1 = generateModification(
       testData1,

--- a/src/state/resolveFinancials/resolveTransactions/transactionNoReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionNoReoccur.test.js
@@ -1,3 +1,4 @@
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 import differenceInCalendarDays from 'date-fns/fp/differenceInDays';
 
@@ -16,8 +17,8 @@ describe(`check transactionNoReoccur`, () => {
     value: 150
   };
   let graphRange = {
-    start: startOfDay('2018-01-01'),
-    end: startOfDay('2018-02-01')
+    start: startOfDay(parseISO('2018-01-01')),
+    end: startOfDay(parseISO('2018-02-01'))
   };
   let seedDate = graphRange.start;
   it(`has all the correct properties`, () => {
@@ -29,7 +30,9 @@ describe(`check transactionNoReoccur`, () => {
   it(`returns the same date`, () => {
     let resolvedTestData = transactionNoReoccur({ transaction, seedDate });
     expect(
-      differenceInCalendarDays(transaction.start)(resolvedTestData.date)
+      differenceInCalendarDays(parseISO(transaction.start))(
+        resolvedTestData.date
+      )
     ).toBe(0);
   });
 });

--- a/src/state/resolveFinancials/resolveTransactions/transactionQuarterlyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionQuarterlyReoccur.test.js
@@ -1,4 +1,5 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { transactionQuarterlyReoccur } from './index.js';
@@ -6,17 +7,17 @@ import { transactionQuarterlyReoccur } from './index.js';
 describe('transactionQuarterlyReoccur', () => {
   it('has the next date', () => {
     const transaction = { value: Big(10), cycle: Big(1) };
-    const seedDate = startOfDay('2018-02-01');
+    const seedDate = startOfDay(parseISO('2018-02-01'));
     const next = transactionQuarterlyReoccur({
       transaction,
       seedDate
     });
-    expect(next.date).toEqual(startOfDay('2018-05-01'));
+    expect(next.date).toEqual(startOfDay(parseISO('2018-05-01')));
   });
 
   it('throws when transaction.cycle=null', () => {
     const transaction = { value: Big(10) };
-    const seedDate = startOfDay('2018-02-01');
+    const seedDate = startOfDay(parseISO('2018-02-01'));
     expect(() => {
       transactionQuarterlyReoccur({
         transaction,
@@ -27,7 +28,7 @@ describe('transactionQuarterlyReoccur', () => {
 
   it('has a value', () => {
     const transaction = { value: Big(10), cycle: Big(1) };
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     const next = transactionQuarterlyReoccur({
       transaction,
       seedDate
@@ -36,7 +37,7 @@ describe('transactionQuarterlyReoccur', () => {
   });
 
   it('throws on missing value', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionQuarterlyReoccur({
         transaction: {},
@@ -46,7 +47,7 @@ describe('transactionQuarterlyReoccur', () => {
   });
 
   it('fails if transaction is null', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionQuarterlyReoccur({ transaction: null, seedDate });
     }).toThrow();

--- a/src/state/resolveFinancials/resolveTransactions/transactionSemiannuallyReoccur.test.js
+++ b/src/state/resolveFinancials/resolveTransactions/transactionSemiannuallyReoccur.test.js
@@ -1,23 +1,24 @@
 import Big from 'big.js';
+import parseISO from 'date-fns/fp/parseISO';
 import startOfDay from 'date-fns/fp/startOfDay';
 
 import { transactionSemiannuallyReoccur } from './index.js';
 
 describe('transactionSemiannuallyReoccur', () => {
   it('has the next date', () => {
-    const transaction = { start: startOfDay('2018-01-01'), value: Big(10) };
-    const seedDate = startOfDay('2018-03-01');
+    const transaction = { start: '2018-01-01', value: Big(10) };
+    const seedDate = startOfDay(parseISO('2018-03-01'));
     const next = transactionSemiannuallyReoccur({
       transaction,
       seedDate,
       occurrences: Big(0)
     });
-    expect(next.date).toEqual(startOfDay('2018-07-01'));
+    expect(next.date).toEqual(startOfDay(parseISO('2018-07-01')));
   });
 
   it('has a value', () => {
-    const transaction = { start: startOfDay('2018-01-01'), value: Big(10) };
-    const seedDate = startOfDay('2018-03-01');
+    const transaction = { start: '2018-01-01', value: Big(10) };
+    const seedDate = startOfDay(parseISO('2018-03-01'));
     const next = transactionSemiannuallyReoccur({
       transaction,
       seedDate,
@@ -27,10 +28,10 @@ describe('transactionSemiannuallyReoccur', () => {
   });
 
   it('throws on missing value', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionSemiannuallyReoccur({
-        transaction: { start: startOfDay('2018-01-01') },
+        transaction: { start: '2018-01-01' },
         seedDate,
         occurrences: Big(0)
       });
@@ -38,7 +39,7 @@ describe('transactionSemiannuallyReoccur', () => {
   });
 
   it('throws on missing start', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionSemiannuallyReoccur({
         transaction: { value: Big(15) },
@@ -49,17 +50,17 @@ describe('transactionSemiannuallyReoccur', () => {
   });
 
   it('throws on missing occurrences', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionSemiannuallyReoccur({
-        transaction: { start: startOfDay('2018-01-01'), value: Big(10) },
+        transaction: { start: '2018-01-01', value: Big(10) },
         seedDate
       });
     }).toThrow();
   });
 
   it('fails if transaction is null', () => {
-    const seedDate = startOfDay('2018-01-01');
+    const seedDate = startOfDay(parseISO('2018-01-01'));
     expect(() => {
       transactionSemiannuallyReoccur({ transaction: null, seedDate });
     }).toThrow();

--- a/src/state/taxStrategy.js
+++ b/src/state/taxStrategy.js
@@ -1,5 +1,6 @@
 import { valueOf, create, StringType, DateType } from 'microstates';
 import { Big } from './customTypes.js';
+import parseISO from 'date-fns/fp/parseISO';
 import getQuarter from 'date-fns/fp/getQuarter';
 
 class Allocations {
@@ -130,7 +131,7 @@ class TaxStrategy {
       }, {});
 
       const quarteredGroup = singleGroup.income.reduce((g, income) => {
-        const quarter = getQuarter(income.date);
+        const quarter = getQuarter(parseISO(income.date));
         const quarterText = quarterAsText(quarter);
         g[quarterText].income = [].concat(g[quarterText].income, income);
         return g;


### PR DESCRIPTION
A breaking change to upgrade date-fns is that we need to explicitly parse date strings now. This will let us merge #88 in.