### PR TITLE
Update dependency date-fns to v2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4602,9 +4602,9 @@
       }
     },
     "date-fns": {
-      "version": "2.0.0-alpha.25",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.25.tgz",
-      "integrity": "sha512-iQzJkHF0L4wah9Ae9PkvwemwFz6qmRLuNZcghmvf2t+ptLs1qXzONLiGtjmPQzL6+JpC01JjlTopY2AEy4NFAg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.1.0.tgz",
+      "integrity": "sha512-eKeLk3sLCnxB/0PN4t1+zqDtSs4jb4mXRSTZ2okmx/myfWyDqeO4r5nnmA5LClJiCwpuTMeK2v5UQPuE4uMaxA=="
     },
     "date-now": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "big.js": "5.2.2",
     "bulma": "0.7.5",
     "d3": "5.11.0",
-    "date-fns": "2.0.0-alpha.25",
+    "date-fns": "2.1.0",
     "formik": "2.0.1-rc.13",
     "js-file-download": "0.4.8",
     "microstates": "0.15.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3638,10 +3638,10 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@2.0.0-alpha.25:
-  version "2.0.0-alpha.25"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.25.tgz#651a5d1f59a01af6cf0371e39b2ae29df5d521ee"
-  integrity sha512-iQzJkHF0L4wah9Ae9PkvwemwFz6qmRLuNZcghmvf2t+ptLs1qXzONLiGtjmPQzL6+JpC01JjlTopY2AEy4NFAg==
+date-fns@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.1.0.tgz#0d7e806c3cefe14a943532dbf968995ccfd46bd9"
+  integrity sha512-eKeLk3sLCnxB/0PN4t1+zqDtSs4jb4mXRSTZ2okmx/myfWyDqeO4r5nnmA5LClJiCwpuTMeK2v5UQPuE4uMaxA==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
This was originally in #88 and should have been merged to `next`. 🤦‍♂ 