### PR TITLE
enable prefers color scheme for dark

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -3,6 +3,7 @@ export default {
   fontSizes: [12, 14, 16, 20, 24, 32, 48, 64],
   initialColorMode: 'light',
   useCustomProperties: true,
+  useColorSchemeMediaQuery: true,
   colors: {
     text: '#000',
     background: '#fff',


### PR DESCRIPTION
This is a new media query that you can set in your browser which color scheme you prefer. The library recently enabled easy use of it.

https://theme-ui.com/color-modes#initialize-dark-mode-with-prefers-color-scheme-dark