### PR TITLE
chore: remove renovate from repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["config:base"],
-  "baseBranches": ["next"],
-  "prHourlyLimit": 1,
-  "labels": ["dependencies"]
-}


### PR DESCRIPTION
We are going to switch to a different provider. Renovate has not been maintained after being bought out.