### PR TITLE
fix: use volta in covector version for lockfile sync

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -16,10 +16,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: 'https://registry.npmjs.org'
+      - uses: volta-cli/action@v1
       - name: git config
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"


### PR DESCRIPTION
We were using an old version of node which caused the lockfile sync to error.