### PR TITLE
feat: avoid babel in parcel

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,6 +1,9 @@
 {
   "extends": "@parcel/config-default",
   "transformers": {
+    "*.{js,jsx,ts,tsx}": [
+      "@parcel/transformer-js"
+    ],
     "url:*": [
       "@parcel/transformer-raw"
     ]


### PR DESCRIPTION
We are only using babel because of jest. Tell parcel to ignore babel when building (this improves bundle size and dev perf).