### PR TITLE
use cargo tree to sync lock file

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -15,7 +15,7 @@
     "app": {
       "path": "./src-tauri/Cargo.toml",
       "version": true,
-      "postversion": "cargo check",
+      "postversion": "cargo tree > /dev/null",
       "getPublishedVersion": "git log v${ pkgFile.version } -1 --pretty=%Cgreen${ pkgFile.version } || echo \"not published yet\"",
       "publish": "echo \"build assets have already been uploaded to release\"",
       "dependencies": ["web"]


### PR DESCRIPTION
`cargo check` fails with our tauri build. Try `cargo tree` instead? It doesn't require a target dir and appears to process near immediately.