### PR TITLE
sync npm with --package-lock-only

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,7 +4,7 @@
     "web": {
       "path": "./package.json",
       "version": true,
-      "postversion": "npm install",
+      "postversion": "npm install --package-lock-only",
       "prepublish": ["npm install", "npm run build"],
       "getPublishedVersion": "git log v${ pkgFile.version } -1 --pretty=%Cgreen${ pkgFile.version } || echo \"not published yet\"",
       "publish": [


### PR DESCRIPTION
This flag should avoid the actual npm install and only sync the lock file.