### PR TITLE
fix nav items not clickable

### DIFF
--- a/.changes/mobile-nav-clickability.md
+++ b/.changes/mobile-nav-clickability.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Update the header with MenuItem and the `react-aria` router integration. This fixes the issue with links not being clickable.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { RouterProvider } from 'react-aria-components';
+import { Routes, Route, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'starfx/react';
 
 import { Footer } from './components/Footer.tsx';
@@ -38,9 +40,10 @@ const FeatureFlag = ({ flag, children }) => {
 
 const App = (props) => {
   const settings = useSelector(schema.settings.select);
+  let navigate = useNavigate();
 
   return (
-    <BrowserRouter>
+    <RouterProvider navigate={navigate}>
       <div className="min-h-full">
         <div className="flex flex-col h-screen">
           <Header settings={settings} />
@@ -161,7 +164,7 @@ const App = (props) => {
           <Footer settings={settings} />
         </div>
       </div>
-    </BrowserRouter>
+    </RouterProvider>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,65 +8,66 @@ import {
   Popover,
   Text
 } from 'react-aria-components';
-import { NavLink } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 
 const navigation = [
-  { name: 'Home', to: '/', end: true },
-  { name: 'Examples', to: 'examples' },
-  { name: 'Accounts', to: 'accounts' },
-  { name: 'Transactions', to: 'transactions' },
-  { name: 'Planning', to: 'planning' },
-  { name: 'Cash Flow', to: 'flow' },
-  { name: 'FI', to: 'financialindependence' },
-  { name: 'Import/Export', to: 'import' },
-  { name: 'Taxes', tag: 'alpha', to: 'taxes' },
-  { name: 'Settings', to: 'settings' }
+  { name: 'Home', to: '/' },
+  { name: 'Examples', to: '/examples' },
+  { name: 'Accounts', to: '/accounts' },
+  { name: 'Transactions', to: '/transactions' },
+  { name: 'Planning', to: '/planning' },
+  { name: 'Cash Flow', to: '/flow' },
+  { name: 'FI', to: '/financialindependence' },
+  { name: 'Import/Export', to: '/import' },
+  { name: 'Taxes', tag: 'alpha', to: '/taxes' },
+  { name: 'Settings', to: '/settings' }
 ];
 
-function ActionItem({ item }: { item: (typeof navigation)[0] }) {
+function renderMenuItem(
+  item: (typeof navigation)[0],
+  css: { default: string; selected: string }
+) {
   return (
     <MenuItem
       id={item.to}
-      className="group flex w-full items-center rounded-md px-3 py-2 box-border outline-none cursor-default text-gray-900 focus:bg-cyan-100 focus:text-white"
+      href={item.to}
+      aria-label={item.name}
+      className={({ isSelected }) =>
+        twMerge(
+          'group flex w-full items-center rounded-md px-3 py-2 box-border outline-none cursor-pointer',
+          isSelected ? css.selected : css.default
+        )
+      }
     >
-      <NavLink
-        to={item.to}
-        className="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
-        end={item.end}
-      >
+      <span className="inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium border-transparent">
         {item.name} {item?.tag ? <sup>{item.tag}</sup> : null}
-      </NavLink>
+      </span>
     </MenuItem>
   );
 }
 
 export const Header = ({ settings }) => {
+  let location = useLocation();
   return (
     <nav className="bg-gradient-to-r to-gray-800 from-cyan-700 pb-36">
       <div className="mx-auto container py-3 px-4 sm:px-6 lg:px-8">
         <div className="lg:flex hidden justify-start h-12">
-          <div className="sm:-my-px md:flex">
-            {navigation
-              .filter((item) => settings[item.to] !== false)
-              .map((item) => (
-                <NavLink
-                  key={item.to}
-                  to={item.to}
-                  className={({ isActive, isPending, isTransitioning }) =>
-                    twMerge(
-                      'inline-flex items-center rounded-md px-4 text-sm font-medium',
-                      isActive
-                        ? 'bg-gray-900 text-white'
-                        : 'text-gray-300 hover:bg-gray-700 hover:text-white'
-                    )
-                  }
-                  end={item.end}
-                >
-                  {item.name} {item?.tag ? <sup>{item.tag}</sup> : null}
-                </NavLink>
-              ))}
-          </div>
+          <Menu
+            className="sm:-my-px md:flex"
+            selectionMode="single"
+            items={navigation.filter((item) => settings[item.to] !== false)}
+            selectedKeys={[location.pathname]}
+          >
+            {(item) =>
+              renderMenuItem(item, {
+                default:
+                  'text-gray-300 hover:bg-gray-700 hover:text-white focus:text-gray-700 focus:border-gray-300 focus:bg-cyan-100',
+                selected:
+                  'text-gray-300 bg-cyan-600 hover:bg-gray-700 hover:text-white'
+              })
+            }
+          </Menu>
         </div>
       </div>
       <div className="mx-auto container flex justify-end lg:hidden">
@@ -78,12 +79,21 @@ export const Header = ({ settings }) => {
             <MenuIcon className="block h-6 w-6" aria-hidden="true" />
           </Button>
           <Popover className="p-1 w-56 overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 entering:animate-in entering:fade-in entering:zoom-in-95 exiting:animate-out exiting:fade-out exiting:zoom-out-95 fill-mode-forwards origin-top-left">
-            <Menu className="outline-none">
-              {navigation
-                .filter((item) => settings[item.to] !== false)
-                .map((item) => (
-                  <ActionItem key={item.to} item={item} />
-                ))}
+            <Menu
+              className="outline-none"
+              aria-label="navigation popover"
+              selectionMode="single"
+              items={navigation.filter((item) => settings[item.to] !== false)}
+              selectedKeys={[location.pathname]}
+            >
+              {(item) =>
+                renderMenuItem(item, {
+                  default:
+                    'text-gray-500 focus:text-gray-700 focus:border-gray-300 focus:bg-cyan-100',
+                  selected:
+                    'text-gray-300 bg-cyan-600 hover:bg-gray-700 hover:text-white'
+                })
+              }
             </Menu>
           </Popover>
         </MenuTrigger>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'starfx/react';
+
+import App from './app.tsx';
 import { schema } from './store/schema.ts';
 import { setupStore } from './store/setup.ts';
-import App from './app.tsx';
 
 const store = setupStore({
   logs: true
@@ -12,7 +14,9 @@ async function init() {
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
       <Provider schema={schema} store={store}>
-        <App />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
       </Provider>
     </React.StrictMode>
   );


### PR DESCRIPTION
## Motivation

I swapped over to `react-aria-components` for the navigation, and didn't wire up the `MenuItem`s in the popover correctly. They weren't clickable. This wholesale updates to their routing mechanism, converts all to `MenuItem` and fixes the clickability.
