### PR TITLE
persist state with reconstitution

### DIFF
--- a/.changes/persist-state-with-reconstitution.md
+++ b/.changes/persist-state-with-reconstitution.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Persist state in local storage through the adapter. This includes logic to reconstitute the dinero objects which are saved as plain objects (stringified) in the state.


### PR DESCRIPTION
## Motivation

We had been close to the code required to save the state in local storage, but we needed some extra logic to handle the more complex objects. After #733, we are able to add some logic to pull back stringified POJOs into the dinero function. With this, we can turn on the state persistence.
