### PR TITLE
expense and transfer reduces loans

### DIFF
--- a/.changes/expense-transfers-on-loans.md
+++ b/.changes/expense-transfers-on-loans.md
@@ -1,0 +1,5 @@
+---
+"web": minor
+---
+
+Expenses and transfers both allow a target account which considers an account decrement on debt, loans and credit lines. This represents the payback of accounts. It saves one from having to make a matching transaction to represent the "out" from one account and "in" in another.

--- a/src/forms/transactionInput.tsx
+++ b/src/forms/transactionInput.tsx
@@ -23,7 +23,7 @@ import { TextField } from '~/src/elements/TextField.tsx';
 const TransactionSchema = z.object({
   id: z.string().optional(),
   raccount: z.string().default('none'),
-  transferIn: z.string().default('none'),
+  transferIn: z.string().default('none').nullable(),
   description: z.string().default(''),
   category: z.string().min(1),
   type: z.enum(['income', 'expense', 'transfer']).default('expense'),
@@ -64,12 +64,13 @@ function TransactionInput() {
   const navigate = useNavigate();
   const { state: locationState } = useLocation();
   const dispatch = useDispatch();
-  const accounts = useSelector(schema.accounts.selectTableAsList);
+  const accountsList = useSelector(schema.accounts.selectTableAsList);
+  const accounts = accountsList.sort((a, b) => (a.name > b.name ? 1 : -1));
   const { Field, handleSubmit, Subscribe, reset, useStore } = useForm({
     defaultValues: locationState?.transaction ?? {
       id: '',
       raccount: 'none',
-      transferIn: undefined,
+      transferIn: 'none',
       description: '',
       category: '',
       type: TransactionSchema.shape.type._def.defaultValue(),
@@ -202,16 +203,18 @@ function TransactionInput() {
             <Field
               name="transferIn"
               children={(field) =>
-                transactionType === 'transfer' ? (
+                transactionType !== 'income' ? (
                   <Select
                     label="Account Target"
                     isRequired={
                       !TransactionSchema.shape.transferIn.isOptional()
                     }
-                    items={accounts}
+                    items={[{ id: 'none', name: 'none' }].concat(accounts)}
                     selectedKey={field.state.value}
                     onBlur={field.handleBlur}
-                    onSelectionChange={(e) => field.handleChange(e)}
+                    onSelectionChange={(e) =>
+                      field.handleChange(e === 'none' ? null : e)
+                    }
                     errorMessage={field.state.meta.errors.join(', ')}
                   >
                     {(item) => <ListBoxItem>{item.name}</ListBoxItem>}

--- a/src/pages/planning/accounts.tsx
+++ b/src/pages/planning/accounts.tsx
@@ -1,6 +1,6 @@
 import { Pencil, Trash2 } from 'lucide-react';
 import React, { useState } from 'react';
-import { Group } from 'react-aria-components';
+import { type ColumnProps, Group } from 'react-aria-components';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 import type { Dispatch } from 'redux';
 import type { AnyAction } from 'starfx';
@@ -93,12 +93,19 @@ const AccountTable = ({
       sortDescriptor={sortable}
     >
       <TableHeader>
-        <Column id="name" isRowHeader allowsSorting>
+        <Column id="name" defaultWidth="3fr" isRowHeader allowsSorting>
           Name
         </Column>
-        {['Starting', 'Interest', 'Vehicle', 'Actions'].map((h) => (
-          <Column key={h} id={h} allowsSorting>
-            {h}
+        {(
+          [
+            ['Starting', '2fr'],
+            ['Interest', '1fr'],
+            ['Vehicle', '2fr'],
+            ['Actions', '2fr']
+          ] as [string, ColumnProps['defaultWidth']][]
+        ).map((h) => (
+          <Column key={h[0]} id={h[0]} defaultWidth={h[1]} allowsSorting>
+            {h[0]}
           </Column>
         ))}
       </TableHeader>

--- a/src/pages/planning/transactions.tsx
+++ b/src/pages/planning/transactions.tsx
@@ -1,7 +1,7 @@
 import { toDecimal } from 'dinero.js';
 import { Pencil, Trash2 } from 'lucide-react';
 import React, { useState } from 'react';
-import { Group } from 'react-aria-components';
+import { type ColumnProps, Group } from 'react-aria-components';
 import { NavigateFunction, useNavigate } from 'react-router-dom';
 import type { Dispatch } from 'redux';
 import type { AnyAction } from 'starfx';
@@ -102,22 +102,22 @@ const TransactionTable = ({
       sortDescriptor={sortable}
     >
       <TableHeader>
-        <Column id="raccount" isRowHeader allowsSorting>
+        <Column id="raccount" defaultWidth="4fr" isRowHeader allowsSorting>
           Account
         </Column>
-        {[
-          'Description',
-          'Category',
-          'Type',
-          'Start',
-          'rtype',
-          'Cycle',
-          'Value',
-          'Daily Rate',
-          'Actions'
-        ].map((h) => (
-          <Column key={h} id={h} allowsSorting>
-            {h}
+        {(
+          [
+            ['Description', '4fr'],
+            ['Category', '2fr'],
+            ['Type', '3fr'],
+            ['Frequency', '4fr'],
+            ['Value', '2fr'],
+            ['Daily Rate', '1fr'],
+            ['Actions', '2fr']
+          ] as [string, ColumnProps['defaultWidth']][]
+        ).map((h) => (
+          <Column key={h[0]} id={h[0]} defaultWidth={h[1]} allowsSorting>
+            {h[0]}
           </Column>
         ))}
       </TableHeader>
@@ -150,13 +150,13 @@ const TransactionRow = ({
     <Cell>{transaction.category}</Cell>
     <Cell>
       {transaction.type}
-      {transaction.type === 'transfer' && transaction.transferIn
-        ? ` to ${transaction.transferIn}`
+      {transaction.transferIn
+        ? `${transaction.type === 'expense' ? ' paid' : ''} to ${transaction.transferIn}`
         : ``}
     </Cell>
-    <Cell>{transaction.start}</Cell>
-    <Cell>{transaction.rtype}</Cell>
-    <Cell>{transaction.cycle}</Cell>
+    <Cell>
+      {transaction.rtype} {transaction.cycle} at {transaction.start}
+    </Cell>
     <Cell>{toHumanCurrency(transaction.value)}</Cell>
     <Cell>{toHumanCurrency(transaction.dailyRate)}</Cell>
 

--- a/src/store/selectors/accounts.ts
+++ b/src/store/selectors/accounts.ts
@@ -107,6 +107,12 @@ function resolveLineChartData({
           account.id,
           'transferIn'
         );
+        const expenseTransfersIn = sumTotal(
+          expensesStacked,
+          index,
+          account.id,
+          'transferIn'
+        );
 
         const prevValue =
           data?.[accountIndex]?.data?.[dateIndex - 1]?.[1] ??
@@ -117,7 +123,15 @@ function resolveLineChartData({
         }
         const firstStep = prevValue - expenses - transfersOut;
         data[accountIndex].data[dateIndex] = [day, firstStep];
-        const secondStep = firstStep + income + transfersIn;
+        const secondStep =
+          firstStep +
+          income +
+          (['debt', 'loan', 'credit line'].includes(account.vehicle)
+            ? transfersIn
+            : -transfersIn) +
+          (['debt', 'loan', 'credit line'].includes(account.vehicle)
+            ? -expenseTransfersIn
+            : expenseTransfersIn);
         if (secondStep > max) max = secondStep;
         data[accountIndex].data[dateIndex + 1] = [day, secondStep];
       }


### PR DESCRIPTION
Expenses and transfers both allow a target account which considers an account decrement on debt, loans and credit lines. This represents the payback of accounts. It saves one from having to make a matching transaction to represent the "out" from one account and "in" in another.