### PR TITLE
remove postinstall for playwright

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "test-e2e": "playwright test",
     "pretty": "prettier --write \"{src,__{tests,mocks}__}/**/*.js\"",
     "playwright": "playwright",
+    "playwright:install": "playwright install --with-deps",
     "tauri": "tauri",
-    "covector": "covector",
-    "postinstall": "playwright install"
+    "covector": "covector"
   },
   "dependencies": {
     "@dinero.js/currencies": "^2.0.0-alpha.14",


### PR DESCRIPTION
## Motivation

We added it for a bit better DX, but it broke some CI expectations where we shouldn't need it. Easier to remove the document.
